### PR TITLE
fix: Change cron schedule to daily for Vercel Hobby plan

### DIFF
--- a/rag-app/vercel.json
+++ b/rag-app/vercel.json
@@ -20,7 +20,7 @@
   "crons": [
     {
       "path": "/api/cron/indexing",
-      "schedule": "*/1 * * * *"
+      "schedule": "0 0 * * *"
     }
   ],
   "headers": [


### PR DESCRIPTION
- Changed from every minute (*/1 * * * *) to daily at midnight (0 0 * * *)
- Vercel Hobby plan only supports daily cron jobs
- Users on Pro plan can change back to more frequent intervals