### PR TITLE
fix: Remove functions configuration from vercel.json

### DIFF
--- a/rag-app/vercel.json
+++ b/rag-app/vercel.json
@@ -3,20 +3,6 @@
   "outputDirectory": "public",
   "framework": "remix",
   "regions": ["iad1"],
-  "functions": {
-    "app/routes/api.*.ts": {
-      "maxDuration": 30
-    },
-    "app/routes/api.*.tsx": {
-      "maxDuration": 30
-    },
-    "app/routes/editor.$pageId.tsx": {
-      "maxDuration": 60
-    },
-    "app/routes/api.cron.indexing.ts": {
-      "maxDuration": 30
-    }
-  },
   "crons": [
     {
       "path": "/api/cron/indexing",


### PR DESCRIPTION
- Remix handles serverless functions differently than standard Vercel API routes
- Functions configuration not needed for Remix apps
- Vercel will auto-detect and configure Remix routes