### PR TITLE
fix: Move build dependencies to dependencies for Vercel

### DIFF
--- a/rag-app/package.json
+++ b/rag-app/package.json
@@ -103,10 +103,12 @@
     "web-vitals": "^5.1.0",
     "winston": "^3.17.0",
     "xlsx": "^0.18.5",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "@remix-run/dev": "^2.17.0",
+    "vite": "^5.4.19",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {
-    "@remix-run/dev": "^2.17.0",
     "@remix-run/testing": "^2.17.0",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
@@ -134,8 +136,6 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.20.4",
     "typescript": "^5.9.2",
-    "vite": "^5.4.19",
-    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^2.1.9"
   },
   "prisma": {


### PR DESCRIPTION
- Move @remix-run/dev, vite, and vite-tsconfig-paths to dependencies
- Vercel needs these during build time
- Fixes 'Cannot find module @remix-run/dev' error