### PR TITLE
fix: Move all build dependencies to dependencies for Vercel

### DIFF
--- a/rag-app/package.json
+++ b/rag-app/package.json
@@ -106,7 +106,12 @@
     "zod": "^3.25.76",
     "@remix-run/dev": "^2.17.0",
     "vite": "^5.4.19",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.9.2",
+    "@vitejs/plugin-react": "^5.0.0"
   },
   "devDependencies": {
     "@remix-run/testing": "^2.17.0",
@@ -121,21 +126,16 @@
     "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",
-    "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^2.1.9",
     "@vitest/ui": "^2.1.9",
-    "autoprefixer": "^10.4.21",
     "eslint": "^8.57.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "happy-dom": "^18.0.1",
     "jsdom": "^25.0.1",
-    "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "prisma": "^6.13.0",
-    "tailwindcss": "^3.4.17",
     "tsx": "^4.20.4",
-    "typescript": "^5.9.2",
     "vitest": "^2.1.9"
   },
   "prisma": {


### PR DESCRIPTION
- Move autoprefixer, postcss, tailwindcss to dependencies
- Move typescript and @vitejs/plugin-react to dependencies
- These are all required during the Vercel build process
- Fixes PostCSS and TypeScript module not found errors