### PR TITLE
fix: Export DatabaseBlockCacheService class for imports

### DIFF
--- a/rag-app/app/services/database-block-cache.server.ts
+++ b/rag-app/app/services/database-block-cache.server.ts
@@ -34,7 +34,7 @@ interface QueryCacheKey {
   pageSize?: number;
 }
 
-class DatabaseBlockCacheService {
+export class DatabaseBlockCacheService {
   // L1: In-memory LRU cache
   private memoryCache: LRUCache<string, CacheEntry<any>>;
   


### PR DESCRIPTION
- Add export keyword to DatabaseBlockCacheService class
- Fixes build error 'DatabaseBlockCacheService is not exported'