### PR TITLE
fix: Add singleton export for aiStreamingService

### DIFF
--- a/rag-app/app/services/streaming/ai-streaming.server.ts
+++ b/rag-app/app/services/streaming/ai-streaming.server.ts
@@ -227,3 +227,6 @@ export class AIStreamingService {
     }
   }
 }
+
+// Export singleton instance
+export const aiStreamingService = new AIStreamingService();


### PR DESCRIPTION
- Export aiStreamingService instance for route imports
- Fixes build error 'aiStreamingService is not exported'