### PR TITLE
fix: Add directUrl to Prisma schema for proper Supabase pooling

### DIFF
--- a/rag-app/prisma/schema.prisma
+++ b/rag-app/prisma/schema.prisma
@@ -6,6 +6,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
   extensions = [uuidOssp(map: "uuid-ossp")]
 }
 


### PR DESCRIPTION
- Add directUrl field to handle migrations separately from runtime queries
- Fixes 'Tenant or user not found' error on Vercel
- DATABASE_URL uses transaction mode (port 6543) for runtime
- DIRECT_URL uses session mode (port 5432) for migrations