### PR TITLE
feat: Add automatic deployment to Hetzner via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to Hetzner
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Deploy to server
+      uses: appleboy/ssh-action@v0.1.5
+      with:
+        host: 178.156.186.87
+        username: root
+        key: ${{ secrets.SERVER_SSH_KEY }}
+        script: |
+          cd /opt/rag-app
+          
+          # Pull latest changes
+          git pull origin main
+          
+          # Build and restart containers
+          docker compose -f docker-compose.production.yml build
+          docker compose -f docker-compose.production.yml down
+          docker compose -f docker-compose.production.yml up -d
+          
+          # Run migrations
+          docker exec rag-app npx prisma migrate deploy
+          
+          # Health check
+          sleep 10
+          curl -f http://localhost:3000/api/health || exit 1
+          
+          echo "Deployment completed successfully!"


### PR DESCRIPTION
This PR adds GitHub Actions workflow for automatic deployment to Hetzner server when pushing to main branch.

## Changes
- Added  for CI/CD pipeline
- Automated deployment process on push to main
- Includes health checks after deployment

## Setup Required
1. Add SSH private key to GitHub secrets as SERVER_SSH_KEY
2. Merge this PR
3. Future pushes to main will auto-deploy to production