### PR TITLE
fix: Critical indexing improvements for full page content

### DIFF
--- a/rag-app/app/utils/db.server.ts
+++ b/rag-app/app/utils/db.server.ts
@@ -25,6 +25,9 @@ function createPrismaClient() {
     if (!url.searchParams.has('connection_limit')) {
       url.searchParams.set('connection_limit', '20');
     }
+    // Increase pool timeout to prevent P2024 errors during heavy indexing
+    url.searchParams.set('pool_timeout', '30'); // 30 seconds instead of default 10
+    url.searchParams.set('connect_timeout', '30'); // 30 seconds connection timeout
     databaseUrl = url.toString();
   }
 


### PR DESCRIPTION
- Increased MAX_CHUNKS_PER_PAGE from 10 to 50 (was limiting content)
- Increased MAX_CHUNK_SIZE from 200 to 400 chars for better context
- Removed 500-char limit on individual blocks (now indexes full content)
- Increased content extraction limit from 8KB to 50KB
- Added connection pool timeout of 30 seconds (fixes P2024 errors)
- Implemented retry mechanism with exponential backoff for indexing
- Improved error logging with full stack traces
- Deferred cleanup service to avoid connection competition
- Fixed batch size from 2 to 5 for better efficiency

These changes ensure ALL content on a page is indexed and searchable