### PR TITLE
fix: Database connection pool exhaustion issues

### DIFF
--- a/rag-app/app/services/connection-pool-manager.server.ts
+++ b/rag-app/app/services/connection-pool-manager.server.ts
@@ -1,0 +1,122 @@
+import { DebugLogger } from '~/utils/debug-logger';
+
+/**
+ * Connection Pool Manager
+ * Manages database operations to prevent connection pool exhaustion
+ */
+export class ConnectionPoolManager {
+  private logger = new DebugLogger('ConnectionPool');
+  private activeOperations = new Set<string>();
+  private operationQueue: Array<() => Promise<void>> = [];
+  private readonly MAX_CONCURRENT_OPERATIONS = 10; // Limit concurrent DB operations
+  private processingQueue = false;
+
+  /**
+   * Execute an operation with connection pool management
+   */
+  async executeWithPoolManagement<T>(
+    operationId: string,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    // If we're at capacity, queue the operation
+    if (this.activeOperations.size >= this.MAX_CONCURRENT_OPERATIONS) {
+      this.logger.info('🚦 Operation queued (pool at capacity)', {
+        operationId,
+        activeCount: this.activeOperations.size,
+        queueLength: this.operationQueue.length
+      });
+
+      return new Promise((resolve, reject) => {
+        this.operationQueue.push(async () => {
+          try {
+            const result = await this.executeOperation(operationId, operation);
+            resolve(result);
+          } catch (error) {
+            reject(error);
+          }
+        });
+        
+        // Process queue if not already processing
+        if (!this.processingQueue) {
+          this.processQueue();
+        }
+      });
+    }
+
+    // Execute immediately if under capacity
+    return this.executeOperation(operationId, operation);
+  }
+
+  private async executeOperation<T>(
+    operationId: string,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    this.activeOperations.add(operationId);
+    
+    try {
+      this.logger.info('🟢 Starting operation', {
+        operationId,
+        activeCount: this.activeOperations.size
+      });
+
+      const result = await operation();
+      
+      this.logger.info('✅ Operation completed', {
+        operationId,
+        activeCount: this.activeOperations.size - 1
+      });
+
+      return result;
+    } catch (error) {
+      this.logger.error('❌ Operation failed', {
+        operationId,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+      throw error;
+    } finally {
+      this.activeOperations.delete(operationId);
+      
+      // Process next in queue if any
+      if (this.operationQueue.length > 0 && !this.processingQueue) {
+        this.processQueue();
+      }
+    }
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processingQueue) return;
+    this.processingQueue = true;
+
+    while (
+      this.operationQueue.length > 0 && 
+      this.activeOperations.size < this.MAX_CONCURRENT_OPERATIONS
+    ) {
+      const operation = this.operationQueue.shift();
+      if (operation) {
+        operation().catch(error => {
+          this.logger.error('Queue operation failed', { error });
+        });
+      }
+    }
+
+    this.processingQueue = false;
+  }
+
+  /**
+   * Get current pool status
+   */
+  getStatus(): {
+    activeOperations: number;
+    queuedOperations: number;
+    maxConcurrent: number;
+  } {
+    return {
+      activeOperations: this.activeOperations.size,
+      queuedOperations: this.operationQueue.length,
+      maxConcurrent: this.MAX_CONCURRENT_OPERATIONS
+    };
+  }
+}
+
+// Singleton instance
+export const connectionPoolManager = new ConnectionPoolManager();

--- a/rag-app/app/utils/db.server.ts
+++ b/rag-app/app/utils/db.server.ts
@@ -20,10 +20,10 @@ function createPrismaClient() {
     url.searchParams.set('pgbouncer', 'true');
     url.searchParams.set('statement_cache_size', '0');
     url.searchParams.set('prepare', 'false');
-    // Use connection limit from URL or default to 20 for production
+    // Use connection limit from URL or default to 50 for production
     // The connection_limit should already be set in DATABASE_URL env var
     if (!url.searchParams.has('connection_limit')) {
-      url.searchParams.set('connection_limit', '20');
+      url.searchParams.set('connection_limit', '50');
     }
     // Increase pool timeout to prevent P2024 errors during heavy indexing
     url.searchParams.set('pool_timeout', '30'); // 30 seconds instead of default 10


### PR DESCRIPTION
- Increased connection pool limit from 20 to 50
- Created ConnectionPoolManager to limit concurrent operations to 10
- Implemented operation queueing when pool is at capacity
- Optimized cleanup queries to use single DELETE instead of SELECT+DELETE
- Added connection pool management to both indexing and cleanup services
- Fixed BigInt conversion in cleanup service

This prevents P2024 timeout errors during heavy load and ensures consistent indexing and cleanup operations even with multiple concurrent save operations.