### PR TITLE
feat: Add collapsible sidebar navigation to editor pages

### DIFF
--- a/rag-app/app/components/editor/EnhancedBlockEditor.tsx
+++ b/rag-app/app/components/editor/EnhancedBlockEditor.tsx
@@ -990,21 +990,6 @@ export const EnhancedBlockEditor = memo(function EnhancedBlockEditor({
 
   return (
     <div className={cn("h-full bg-white flex flex-col", className)}>
-      {/* Toolbar */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 bg-gray-50">
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-gray-500">
-            {blocks.length} block{blocks.length !== 1 ? 's' : ''}
-          </span>
-        </div>
-        <button
-          onClick={() => onSave?.(blocks)}
-          className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700"
-        >
-          Save
-        </button>
-      </div>
-      
       {/* Editor content */}
       <div className="flex-1 overflow-y-auto">
         {blocks.map((block, index) => (

--- a/rag-app/app/components/editor/LexicalBlockEditor.tsx
+++ b/rag-app/app/components/editor/LexicalBlockEditor.tsx
@@ -313,15 +313,6 @@ export const LexicalBlockEditor = memo(function LexicalBlockEditor({
 
   return (
     <div className={cn("h-full bg-white flex flex-col", className)}>
-      {/* Toolbar */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 bg-gray-50">
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-gray-500">
-            {blocks.length} block{blocks.length !== 1 ? 's' : ''}
-          </span>
-        </div>
-      </div>
-      
       {/* Editor content */}
       <div className="flex-1 overflow-y-auto">
         {blocks.map((block, index) => (

--- a/rag-app/app/routes/editor.$pageId.tsx
+++ b/rag-app/app/routes/editor.$pageId.tsx
@@ -1,9 +1,9 @@
 import { json, LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
-import { useLoaderData, useFetcher, Link } from "@remix-run/react";
+import { useLoaderData, useFetcher, Link, NavLink, useLocation } from "@remix-run/react";
 import { EnhancedBlockEditor } from "~/components/editor/EnhancedBlockEditor";
 import { ClientOnly } from "~/components/ClientOnly";
 import { prisma } from "~/utils/db.server";
-import { requireUser } from "~/services/auth/auth.server";
+import { requireUser, getUser } from "~/services/auth/auth.server";
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { Block } from "~/types/blocks";
 import { debounce } from "~/utils/performance";
@@ -15,13 +15,33 @@ import { ultraLightIndexingService } from "~/services/rag/ultra-light-indexing.s
 import { blockManipulationIntegration } from "~/services/ai/block-manipulation-integration.server";
 import { pageHierarchyService } from "~/services/page-hierarchy.server";
 import { AIBlockService } from "~/services/ai-block-service.server";
+import { PageTreeNavigation } from "~/components/navigation/PageTreeNavigation";
+import type { PageTreeNode } from "~/components/navigation/PageTreeNavigation";
+import { UserMenu } from "~/components/navigation/UserMenu";
+import { ThemeToggle } from "~/components/theme/ThemeToggle";
+import { CommandPalette } from "~/components/navigation/CommandPalette";
+import { 
+  HomeIcon, 
+  DocumentIcon, 
+  Cog6ToothIcon,
+  MagnifyingGlassIcon,
+  BellIcon,
+  Bars3Icon,
+  XMarkIcon,
+  ChevronDownIcon,
+  PlusIcon,
+} from "@heroicons/react/24/outline";
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const { pageId } = params;
   if (!pageId) throw new Response("Page ID required", { status: 400 });
 
   // Get authenticated user
-  const user = await requireUser(request);
+  const user = await getUser(request);
+  
+  if (!user) {
+    throw new Response("Unauthorized", { status: 401 });
+  }
 
   // Get page details with workspace (no project required)
   const page = await prisma.page.findUnique({
@@ -64,6 +84,55 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   
   // Get page breadcrumb path for navigation
   const breadcrumbPath = await pageHierarchyService.getPagePath(pageId);
+
+  // Get user's workspaces for workspace switcher
+  let userWorkspaces: Array<{
+    id: string;
+    userId: string;
+    workspaceId: string;
+    roleId: string;
+    workspace: {
+      id: string;
+      name: string;
+      slug: string;
+      description: string | null;
+    };
+    role: {
+      id: string;
+      name: string;
+    };
+  }> = [];
+  
+  try {
+    userWorkspaces = await prisma.userWorkspace.findMany({
+      where: { userId: user.id },
+      include: {
+        workspace: true,
+        role: true,
+      },
+      orderBy: {
+        workspace: {
+          name: 'asc'
+        }
+      }
+    });
+  } catch (error) {
+    console.error('Error fetching workspaces:', error);
+  }
+
+  // Get current workspace
+  const currentWorkspaceId = page.workspaceId;
+  const currentWorkspace = userWorkspaces.find(uw => uw?.workspace.id === currentWorkspaceId)?.workspace || page.workspace;
+
+  // Get page tree for current workspace
+  let pageTree: PageTreeNode[] = [];
+  if (currentWorkspace) {
+    try {
+      pageTree = await pageHierarchyService.getPageTree(currentWorkspace.id, 5);
+    } catch (e) {
+      console.error('Error fetching page tree:', e);
+    }
+  }
 
   // Extract blocks or convert content to blocks
   const metadata = typeof page.metadata === 'object' && page.metadata ? page.metadata : {};
@@ -140,8 +209,12 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   }
 
   return json({
+    user,
     page,
     workspace: page.workspace,
+    workspaces: userWorkspaces,
+    currentWorkspace,
+    pageTree,
     parent: page.parent,
     children: page.children,
     breadcrumbPath,
@@ -537,8 +610,16 @@ export async function action({ params, request }: ActionFunctionArgs) {
   return json({ error: "Invalid intent" }, { status: 400 });
 }
 
+interface NavigationItem {
+  name: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  current?: boolean;
+}
+
 export default function EditorPage() {
-  const { page, workspace, parent, children, breadcrumbPath, content: initialContent, blocks: initialBlocks, canEdit } = useLoaderData<typeof loader>();
+  const { user, page, workspace, workspaces, currentWorkspace, pageTree, parent, children, breadcrumbPath, content: initialContent, blocks: initialBlocks, canEdit } = useLoaderData<typeof loader>();
+  const location = useLocation();
   const fetcher = useFetcher();
   const [blocks, setBlocks] = useState(initialBlocks);
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
@@ -546,8 +627,35 @@ export default function EditorPage() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
   const [processingAI, setProcessingAI] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [workspaceDropdownOpen, setWorkspaceDropdownOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const maxRetries = 3;
   const retryTimeoutRef = useRef<NodeJS.Timeout>();
+
+  // Main navigation items
+  const navigation: NavigationItem[] = [
+    { name: 'Home', href: '/app', icon: HomeIcon },
+    { name: 'Search', href: '/app/search', icon: MagnifyingGlassIcon },
+    { name: 'Settings', href: '/app/settings', icon: Cog6ToothIcon },
+  ];
+
+  // Close mobile sidebar when route changes
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [location.pathname]);
+
+  // Close dropdowns when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as HTMLElement;
+      if (!target.closest('[data-dropdown="workspace"]')) {
+        setWorkspaceDropdownOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   const handleSave = async (newBlocks: Block[], isRetry = false) => {
     if (!isRetry) {
@@ -690,71 +798,217 @@ export default function EditorPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-gray-50 flex">
-      {/* Sidebar Navigation */}
-      <div className="w-64 bg-white border-r border-gray-200 flex flex-col">
-        {/* Workspace Header */}
-        <div className="p-4 border-b border-gray-200">
-          <Link to="/app" className="flex items-center space-x-2 text-gray-900 hover:text-gray-700">
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-            </svg>
-            <span className="font-semibold">{workspace.name}</span>
-          </Link>
+    <div className="h-full flex">
+      {/* Mobile sidebar backdrop */}
+      {sidebarOpen && (
+        <div 
+          className="lg:hidden fixed inset-0 z-40 bg-gray-600 bg-opacity-75"
+          onClick={() => setSidebarOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Sidebar - same as app.tsx */}
+      <aside 
+        className={`
+          ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
+          lg:translate-x-0 fixed lg:static inset-y-0 left-0 z-50 w-64 
+          bg-white dark:bg-[rgba(33,33,33,1)] border-r border-gray-200 dark:border-[rgba(33, 33, 33, 1)] transition-transform duration-300 ease-in-out
+          flex flex-col h-full
+        `}
+        aria-label="Main navigation"
+      >
+        {/* Workspace Switcher */}
+        <div className="flex-shrink-0 p-2">
+          <div className="relative" data-dropdown="workspace">
+            <button
+              onClick={() => setWorkspaceDropdownOpen(!workspaceDropdownOpen)}
+              className="w-full flex items-center justify-between px-3 py-0.7 text-sm font-medium text-gray-900 dark:text-gray-100 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+              aria-label="Switch workspace"
+              aria-expanded={workspaceDropdownOpen}
+              aria-haspopup="true"
+            >
+              <div className="flex items-center min-w-0">
+                <div className="flex-shrink-0 w-8 h-8 bg-gradient-to-br from-blue-500 to-blue-600 rounded-lg flex items-center justify-center text-white font-semibold">
+                  {currentWorkspace?.name.charAt(0).toUpperCase() || 'W'}
+                </div>
+                <span className="ml-3 truncate">{currentWorkspace?.name || 'Workspace'}</span>
+              </div>
+              <ChevronDownIcon className="ml-2 h-4 w-4 text-gray-500 flex-shrink-0" />
+            </button>
+
+            {/* Workspace Dropdown */}
+            {workspaceDropdownOpen && (
+              <div className="absolute top-full left-0 right-0 mt-1 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-10 dark:bg-[rgba(33,33,33,1)]">
+                <div className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Workspaces
+                </div>
+                {workspaces.map((uw) => uw && (
+                  <Link
+                    key={uw.workspace.id}
+                    to={`/app/workspace/${uw.workspace.slug}`}
+                    className={`
+                      flex items-center px-3 py-2 text-sm dark:bg-[rgba(33,33,33,1)] dark:hover:bg-gray-50
+                      ${uw.workspace.id === currentWorkspace?.id ? 'bg-blue-50 text-blue-700 dark:text-white' : 'text-gray-700'}
+                    `}
+                  >
+                    <div className="flex-shrink-0 w-6 h-6 bg-gradient-to-br from-gray-400 to-gray-500 rounded flex items-center justify-center text-white text-xs font-semibold">
+                      {uw.workspace.name.charAt(0).toUpperCase()}
+                    </div>
+                    <span className="ml-3 truncate">{uw.workspace.name}</span>
+                    <span className="ml-auto text-xs text-gray-500">{uw.role.name}</span>
+                  </Link>
+                ))}
+                <div className="border-t border-gray-200 mt-1 pt-1">
+                  <Link
+                    to="/app/workspace/new"
+                    className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                  >
+                    <PlusIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    Create workspace
+                  </Link>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
-        
-        {/* Navigation Links */}
-        <nav className="flex-1 p-4 space-y-1">
-          <Link 
-            to="/app" 
-            className="flex items-center space-x-2 px-3 py-2 text-gray-700 rounded-lg hover:bg-gray-100"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-            </svg>
-            <span>Dashboard</span>
-          </Link>
-          
-          <Link 
-            to={`/app/workspaces/${workspace.id}/pages`}
-            className="flex items-center space-x-2 px-3 py-2 text-gray-700 rounded-lg hover:bg-gray-100"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
-            <span>All Pages</span>
-          </Link>
-          
-          <Link 
-            to="/app/rag"
-            className="flex items-center space-x-2 px-3 py-2 text-gray-700 rounded-lg hover:bg-gray-100"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-            <span>Search</span>
-          </Link>
+
+        {/* Navigation */}
+        <nav className="flex-1 overflow-y-auto p-4 space-y-1" aria-label="Primary navigation">
+          {navigation.map((item) => {
+            const Icon = item.icon;
+            
+            // Special handling for Search - opens command palette instead of navigating
+            if (item.name === 'Search') {
+              return (
+                <button
+                  key={item.name}
+                  onClick={() => setCommandPaletteOpen(true)}
+                  className="w-full flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-colors text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                  <Icon className="mr-3 h-5 w-5 flex-shrink-0" />
+                  {item.name}
+                </button>
+              );
+            }
+            
+            return (
+              <NavLink
+                key={item.name}
+                to={item.href}
+                className={({ isActive }) => `
+                  flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-colors
+                  ${isActive 
+                    ? 'bg-blue-50 text-blue-700 dark:bg-blue-900 dark:text-blue-200' 
+                    : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700'
+                  }
+                `}
+              >
+                <Icon className="mr-3 h-5 w-5 flex-shrink-0" />
+                {item.name}
+              </NavLink>
+            );
+          })}
+
+          {/* Pages Section */}
+          <div className="pt-4">
+            <div className="flex items-center justify-between px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+              <div className="flex items-center">
+                <DocumentIcon className="mr-3 h-5 w-5" />
+                <span>Pages</span>
+              </div>
+              <Link
+                to="/app/pages/new"
+                className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 rounded"
+                aria-label="Create new page"
+              >
+                <PlusIcon className="h-4 w-4" />
+              </Link>
+            </div>
+            
+            {/* Page Tree Navigation */}
+            <div className="mt-1">
+              <PageTreeNavigation
+                workspaceSlug={currentWorkspace?.slug || ''}
+                pages={pageTree as PageTreeNode[]}
+                currentPageId={page.id}
+                onCreatePage={(parentId) => {
+                  // Navigate to create page route
+                  window.location.href = `/app/pages/new${parentId ? `?parentId=${parentId}` : ''}`;
+                }}
+                onMovePage={async (pageId, newParentId) => {
+                  // Call API to move page
+                  const formData = new FormData();
+                  if (newParentId) formData.append('parentId', newParentId);
+                  
+                  const response = await fetch(`/api/pages/${pageId}`, {
+                    method: 'PATCH',
+                    body: formData
+                  });
+                  
+                  if (response.ok) {
+                    window.location.reload();
+                  } else {
+                    console.error('Failed to move page');
+                  }
+                }}
+                onDeletePage={async (pageId) => {
+                  // Call API to delete page
+                  const response = await fetch(`/api/pages/${pageId}`, {
+                    method: 'DELETE'
+                  });
+                  
+                  if (response.ok) {
+                    window.location.reload();
+                  } else {
+                    console.error('Failed to delete page');
+                  }
+                }}
+              />
+            </div>
+          </div>
         </nav>
-        
-        {/* User Menu at Bottom */}
-        <div className="p-4 border-t border-gray-200">
-          <Link 
-            to="/app/settings"
-            className="flex items-center space-x-2 px-3 py-2 text-gray-700 rounded-lg hover:bg-gray-100"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
-            <span>Settings</span>
-          </Link>
+
+        {/* User Menu */}
+        <div className="flex-shrink-0 p-4 border-t border-gray-200">
+          <UserMenu user={user} currentWorkspace={currentWorkspace ? { id: currentWorkspace.id, name: currentWorkspace.name } : undefined} />
         </div>
-      </div>
+      </aside>
 
       {/* Main Content Area */}
-      <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Top Header with mobile menu button */}
+        <header className="flex-shrink-0 bg-white dark:bg-[rgba(33,33,33,1)] dark:border-[rgba(33, 33, 33, 1)]">
+          <div className="flex items-center justify-between h-12 px-4 lg:px-6">
+            {/* Mobile menu button */}
+            <button
+              onClick={() => setSidebarOpen(!sidebarOpen)}
+              className="lg:hidden p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label={sidebarOpen ? 'Close navigation menu' : 'Open navigation menu'}
+              aria-expanded={sidebarOpen}
+            >
+              {sidebarOpen ? (
+                <XMarkIcon className="h-6 w-6" />
+              ) : (
+                <Bars3Icon className="h-6 w-6" />
+              )}
+            </button>
+
+            {/* Spacer */}
+            <div className="flex-1"></div>
+
+            {/* Right side buttons */}
+            <div className="flex items-center space-x-3">
+              <ThemeToggle />
+              <button className="p-2 text-gray-400 hover:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg">
+                <BellIcon className="h-5 w-5" />
+              </button>
+            </div>
+          </div>
+        </header>
+
         {/* Page header */}
-        <div className="bg-white shadow-sm border-b border-gray-200 px-6 py-3">
+        <div className="bg-white dark:bg-[rgba(33,33,33,1)] shadow-sm border-b border-gray-200 dark:border-gray-700 px-6 py-3">
           <div className="flex items-center justify-between">
             <div>
               <div className="text-xs text-gray-500">
@@ -793,19 +1047,27 @@ export default function EditorPage() {
         </div>
 
         {/* Editor */}
-        <div className="flex-1 overflow-hidden bg-white">
-        <ClientOnly fallback={<div className="h-full bg-white animate-pulse" />}>
-          <EnhancedBlockEditor
-            initialBlocks={blocks}
-            onChange={handleChange}
-            onSave={handleSave}
-            workspaceId={workspace.id}
-            className="h-full"
-            onAICommand={handleAICommand}
-          />
-        </ClientOnly>
+        <div className="flex-1 overflow-hidden bg-white dark:bg-[rgba(33,33,33,1)]">
+          <ClientOnly fallback={<div className="h-full bg-white dark:bg-[rgba(33,33,33,1)] animate-pulse" />}>
+            <EnhancedBlockEditor
+              initialBlocks={blocks}
+              onChange={handleChange}
+              onSave={handleSave}
+              workspaceId={workspace.id}
+              className="h-full"
+              onAICommand={handleAICommand}
+            />
+          </ClientOnly>
         </div>
       </div>
+      
+      {/* Command Palette - rendered as modal */}
+      <ClientOnly fallback={null}>
+        <CommandPalette 
+          open={commandPaletteOpen} 
+          onClose={() => setCommandPaletteOpen(false)} 
+        />
+      </ClientOnly>
     </div>
   );
 }


### PR DESCRIPTION
- Implement same collapsible sidebar from main app in editor pages
- Add workspace switcher dropdown with all user workspaces
- Include PageTreeNavigation component for hierarchical page navigation
- Add UserMenu and ThemeToggle components to sidebar
- Make sidebar mobile responsive with hamburger menu and backdrop
- Add command palette modal for search functionality
- Remove simplified navigation in favor of full-featured sidebar