### PR TITLE
fix: Fix page deletion error in production

### DIFF
--- a/rag-app/app/routes/api.pages.$pageId.tsx
+++ b/rag-app/app/routes/api.pages.$pageId.tsx
@@ -22,8 +22,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
       
       // Delete all pages in a transaction
       await prisma.$transaction(async (tx) => {
-        // Delete blocks first
-        await tx.block.deleteMany({
+        // Delete related embeddings first
+        await tx.pageEmbedding.deleteMany({
+          where: { pageId: { in: pageIdsToDelete } }
+        });
+        
+        await tx.blockEmbedding.deleteMany({
           where: { pageId: { in: pageIdsToDelete } }
         });
         


### PR DESCRIPTION
- Remove reference to non-existent 'block' model in Prisma transaction
- Delete PageEmbedding and BlockEmbedding records instead
- Fixes 'Cannot read properties of undefined (reading deleteMany)' error