### PR TITLE
fix: Increase connection limits for transaction pooler

### DIFF
--- a/rag-app/app/services/connection-pool-manager.server.ts
+++ b/rag-app/app/services/connection-pool-manager.server.ts
@@ -71,8 +71,8 @@ export class ConnectionPoolManager {
               return operation(tx as PrismaClient);
             },
             {
-              maxWait: 5000,
-              timeout,
+              maxWait: 10000, // Increased to 10s for queue wait
+              timeout: timeout || 15000, // Default 15s for transaction
               isolationLevel,
             }
           );

--- a/rag-app/app/utils/db-pooling.server.ts
+++ b/rag-app/app/utils/db-pooling.server.ts
@@ -39,8 +39,8 @@ export function getPoolingConfig(): PoolingConfig {
     // Transaction pooler configuration (port 6543)
     // Does NOT support PREPARE statements outside transactions
     return {
-      connectionLimit: 1, // Minimal connections for transaction pooler
-      poolTimeout: 10, // 10 seconds timeout
+      connectionLimit: 5, // Allow 5 connections for concurrent operations within requests
+      poolTimeout: 20, // 20 seconds timeout for complex operations
       connectTimeout: 10, // 10 seconds max to connect
       statementCacheSize: 0, // No statement caching in transaction mode
       pgbouncer: true,
@@ -84,11 +84,11 @@ export function buildDatabaseUrl(baseUrl?: string): string {
   
   // Set PgBouncer parameters based on port
   if (originalPort === '6543') {
-    // Transaction pooler - strict settings
+    // Transaction pooler - balanced settings for Vercel
     url.searchParams.set('pgbouncer', 'true');
     url.searchParams.set('statement_cache_size', '0');
     url.searchParams.set('prepare', 'false');
-    url.searchParams.set('connection_limit', '1'); // Minimal for transaction mode
+    url.searchParams.set('connection_limit', config.connectionLimit.toString()); // Use config value
   } else if (url.hostname.includes('pooler.')) {
     // Session pooler
     url.searchParams.set('pgbouncer', 'true');


### PR DESCRIPTION
The issue: connection_limit=1 was too restrictive, causing P2024 errors when operations needed concurrent queries within a single request.

Changes:
- Increased connection_limit from 1 to 5 for transaction pooler
- Increased pool_timeout from 10 to 20 seconds for complex operations
- Increased transaction maxWait to 10s and default timeout to 15s
- Now properly handles concurrent operations like indexing

This balances the efficiency of transaction pooler with the reality that some operations (like indexing with transactions) need multiple concurrent connections.

🤖 Generated with [Claude Code](https://claude.ai/code)