### PR TITLE
fix: Resolve Redis localhost fallback issue

### DIFF
--- a/rag-app/app/utils/redis.server.ts
+++ b/rag-app/app/utils/redis.server.ts
@@ -1,47 +1,99 @@
 import Redis from "ioredis";
 import { redisFactory } from "./redis-factory.server";
+import { DebugLogger } from "./debug-logger";
+
+const logger = new DebugLogger('Redis');
 
 let redis: Redis;
 let redisWorker: Redis;
+let initializationPromise: Promise<void> | null = null;
 
 declare global {
   // eslint-disable-next-line no-var
   var __redis__: Redis;
+  // eslint-disable-next-line no-var
   var __redisWorker__: Redis;
+  // eslint-disable-next-line no-var
   var __redisInitialized__: boolean;
+  // eslint-disable-next-line no-var
+  var __redisInitPromise__: Promise<void> | null;
 }
 
 // Initialize Redis with factory pattern
 async function initializeRedis() {
   if (global.__redisInitialized__) {
+    logger.trace('Redis already initialized');
     return;
   }
   
   try {
+    logger.info('Initializing Redis factory');
     await redisFactory.initialize();
     global.__redisInitialized__ = true;
+    logger.info('Redis factory initialized successfully');
   } catch (error) {
-    console.error('Failed to initialize Redis:', error);
-    // Fall back to direct connection for backwards compatibility
-    const fallbackUrl = process.env["REDIS_URL"] || "redis://localhost:6379";
-    redis = new Redis(fallbackUrl);
-    redisWorker = new Redis(fallbackUrl, {
-      maxRetriesPerRequest: null,
-      enableReadyCheck: true,
-      reconnectOnError: (err: Error) => err.message.includes("READONLY"),
+    logger.error('Failed to initialize Redis factory:', error);
+    
+    // Improved fallback - only use REDIS_URL, never localhost
+    const fallbackUrl = process.env["REDIS_URL"];
+    
+    if (!fallbackUrl) {
+      logger.error('REDIS_URL environment variable is not set');
+      throw new Error('Redis initialization failed: REDIS_URL not configured');
+    }
+    
+    logger.warn('Attempting direct Redis connection as fallback', {
+      url: fallbackUrl.replace(/:[^:@]+@/, ':****@')
     });
-    return;
+    
+    try {
+      redis = new Redis(fallbackUrl, {
+        retryStrategy: (times) => {
+          if (times > 3) {
+            logger.error('Redis connection failed after 3 retries');
+            return null;
+          }
+          const delay = Math.min(times * 100, 2000);
+          logger.warn(`Retrying Redis connection in ${delay}ms (attempt ${times})`);
+          return delay;
+        },
+        connectTimeout: 10000,
+        lazyConnect: false,
+      });
+      
+      redisWorker = new Redis(fallbackUrl, {
+        maxRetriesPerRequest: null,
+        enableReadyCheck: true,
+        reconnectOnError: (err: Error) => err.message.includes("READONLY"),
+        retryStrategy: (times) => Math.min(times * 100, 2000),
+        connectTimeout: 10000,
+      });
+      
+      // Wait for connections to be ready
+      await redis.ping();
+      await redisWorker.ping();
+      
+      logger.info('Direct Redis connection established successfully');
+      global.__redisInitialized__ = true;
+      return;
+    } catch (fallbackError) {
+      logger.error('Direct Redis connection failed:', fallbackError);
+      throw new Error(`Redis initialization failed: ${fallbackError}`);
+    }
   }
   
   // Get clients from factory
   const provider = redisFactory.getProvider();
+  logger.info('Redis provider type:', { type: provider.type });
   
-  if (provider.type === 'local') {
-    // For local Redis, use the actual ioredis clients
+  if (provider.type === 'local' || provider.type === 'railway') {
+    // For local/Railway Redis, use the actual ioredis clients
     redis = redisFactory.getClient() as Redis;
     redisWorker = redisFactory.getClient({ workerMode: true }) as Redis;
-  } else {
+    logger.info('Using ioredis clients for Redis');
+  } else if (provider.type === 'upstash') {
     // For managed services, create wrapper
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const createWrapper = (provider: any): Redis => {
       const wrapper = Object.create(Redis.prototype);
       wrapper.get = provider.get.bind(provider);
@@ -58,23 +110,76 @@ async function initializeRedis() {
     
     redis = createWrapper(provider);
     redisWorker = redis; // Use same client for workers with Upstash
+    logger.info('Using wrapper for Upstash Redis');
+  } else {
+    logger.warn('Unknown Redis provider type, using no-op provider');
+    // For no-op provider, redis and redisWorker will remain undefined
+    // This should be handled by calling code
   }
+}
+
+// Ensure Redis is initialized before use
+async function ensureRedisInitialized(): Promise<void> {
+  if (global.__redisInitialized__ && redis && redisWorker) {
+    return;
+  }
+  
+  // Use global promise to prevent multiple initialization attempts
+  if (!initializationPromise) {
+    if (global.__redisInitPromise__) {
+      initializationPromise = global.__redisInitPromise__;
+    } else {
+      initializationPromise = initializeRedis().then(() => {
+        if (process.env["NODE_ENV"] !== "production") {
+          global.__redis__ = redis;
+          global.__redisWorker__ = redisWorker;
+        }
+      });
+      
+      if (process.env["NODE_ENV"] !== "production") {
+        global.__redisInitPromise__ = initializationPromise;
+      }
+    }
+  }
+  
+  await initializationPromise;
 }
 
 // Initialize on module load
 if (process.env["NODE_ENV"] === "production") {
-  initializeRedis().catch(console.error);
+  // In production, initialize immediately but don't block
+  ensureRedisInitialized().catch((error) => {
+    logger.error('Failed to initialize Redis in production:', error);
+  });
 } else {
   // Development mode with global caching
-  if (!global.__redis__) {
-    initializeRedis().then(() => {
-      global.__redis__ = redis;
-      global.__redisWorker__ = redisWorker;
-    }).catch(console.error);
-  } else {
+  if (global.__redis__ && global.__redisWorker__) {
     redis = global.__redis__;
     redisWorker = global.__redisWorker__;
+    logger.trace('Using cached Redis clients from global');
+  } else {
+    // Initialize asynchronously
+    ensureRedisInitialized().catch((error) => {
+      logger.error('Failed to initialize Redis in development:', error);
+    });
   }
+}
+
+// Export a function to ensure Redis is ready
+export async function getRedis(): Promise<Redis> {
+  await ensureRedisInitialized();
+  if (!redis) {
+    throw new Error('Redis client not available');
+  }
+  return redis;
+}
+
+export async function getRedisWorker(): Promise<Redis> {
+  await ensureRedisInitialized();
+  if (!redisWorker) {
+    throw new Error('Redis worker client not available');
+  }
+  return redisWorker;
 }
 
 export { redis, redisWorker, redisFactory };


### PR DESCRIPTION
- Remove dangerous localhost:6379 fallback in redis.server.ts
- Add proper async initialization with getRedis() and getRedisWorker() functions
- Improve error handling to fail fast instead of silently falling back
- Update embedding worker to use async Redis initialization
- Convert queue configs to async functions for proper initialization
- Add better logging throughout Redis initialization process

This fixes the ECONNREFUSED 127.0.0.1:6379 error by:
1. Never falling back to localhost when REDIS_URL is set
2. Ensuring Redis is properly initialized before use
3. Providing clear error messages when Redis is unavailable
4. Using Railway Redis connection consistently