### PR TITLE
fix: Complete resolution of Redis and database issues

### DIFF
--- a/rag-app/prisma/schema.prisma
+++ b/rag-app/prisma/schema.prisma
@@ -7,7 +7,7 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
-  extensions = [uuidOssp(map: "uuid-ossp")]
+  extensions = [uuidOssp(map: "uuid-ossp"), vector]
 }
 
 model User {
@@ -302,7 +302,8 @@ model Embedding {
   documentId String                   @map("document_id") @db.Uuid
   chunkText  String                   @map("chunk_text") @db.Text
   chunkIndex Int                      @map("chunk_index")
-  // embedding  Unsupported("vector(1536)")? // Temporarily disabled - requires pgvector extension
+  embedding  Unsupported("vector(1536)")? // Full vector embedding
+  embeddingHalfvec Unsupported("halfvec(1536)")? @map("embedding_halfvec") // Halfvec for storage optimization
   metadata   Json?                    @db.JsonB
   createdAt  DateTime                 @default(now()) @map("created_at") @db.Timestamptz(6)
   document   Document                 @relation(fields: [documentId], references: [id], onDelete: Cascade)
@@ -317,7 +318,8 @@ model PageEmbedding {
   workspaceId String                  @map("workspace_id") @db.Uuid
   chunkText  String                   @map("chunk_text") @db.Text
   chunkIndex Int                      @map("chunk_index")
-  // embedding  Unsupported("vector(1536)")? // Requires pgvector extension
+  embedding  Unsupported("vector(1536)")? // Full vector embedding
+  embeddingHalfvec Unsupported("halfvec(1536)")? @map("embedding_halfvec") // Halfvec for storage optimization
   metadata   Json?                    @db.JsonB
   createdAt  DateTime                 @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt  DateTime                 @default(now()) @map("updated_at") @db.Timestamptz(6)
@@ -338,7 +340,8 @@ model BlockEmbedding {
   workspaceId String                  @map("workspace_id") @db.Uuid
   chunkText  String                   @map("chunk_text") @db.Text
   chunkIndex Int                      @map("chunk_index")
-  // embedding  Unsupported("vector(1536)")? // Requires pgvector extension
+  embedding  Unsupported("vector(1536)")? // Full vector embedding
+  embeddingHalfvec Unsupported("halfvec(1536)")? @map("embedding_halfvec") // Halfvec for storage optimization
   metadata   Json?                    @db.JsonB
   createdAt  DateTime                 @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt  DateTime                 @default(now()) @map("updated_at") @db.Timestamptz(6)
@@ -358,7 +361,8 @@ model DatabaseRowEmbedding {
   pageId     String?                  @map("page_id") @db.Uuid
   workspaceId String                  @map("workspace_id") @db.Uuid
   chunkText  String                   @map("chunk_text") @db.Text
-  // embedding  Unsupported("vector(1536)")? // Requires pgvector extension
+  embedding  Unsupported("vector(1536)")? // Full vector embedding
+  embeddingHalfvec Unsupported("halfvec(1536)")? @map("embedding_halfvec") // Halfvec for storage optimization
   metadata   Json?                    @db.JsonB
   createdAt  DateTime                 @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt  DateTime                 @default(now()) @map("updated_at") @db.Timestamptz(6)


### PR DESCRIPTION
- Fix Redis provider type definition to include 'railway'
- Fix UltraLightEmbeddingQueue to use async Redis initialization
- Add vector and halfvec types to Prisma schema for pgvector support
- Fix all TypeScript environment variable access using bracket notation
- Update embedding worker to use getEmbeddingWorkerConfig()

This resolves:
1. ECONNREFUSED 127.0.0.1:6379 - No more localhost fallback
2. Vector type does not exist - pgvector extension now configured
3. IDE TypeScript errors - All fixed with proper types