### PR TITLE
fix: Revert vector type references to use search_path instead of expl…

### DIFF
--- a/rag-app/app/routes/api.index-page.tsx
+++ b/rag-app/app/routes/api.index-page.tsx
@@ -89,7 +89,7 @@ export async function action({ request }: ActionFunctionArgs) {
         ${page.workspaceId}::uuid,
         ${textContent},
         0,
-        ${`[${embedding.join(',')}]`}::extensions.vector,
+        ${`[${embedding.join(',')}]`}::vector,
         ${JSON.stringify({ 
           title: page.title,
           projectId: page.projectId,

--- a/rag-app/app/scripts/migrate-to-halfvec.ts
+++ b/rag-app/app/scripts/migrate-to-halfvec.ts
@@ -161,7 +161,7 @@ class HalfvecMigrator {
             OFFSET ${offset}
           )
           UPDATE ${tableName} t
-          SET embedding_halfvec = t.embedding::extensions.halfvec(1536)
+          SET embedding_halfvec = t.embedding::halfvec(1536)
           FROM batch
           WHERE t.id = batch.id
         `);
@@ -222,7 +222,7 @@ class HalfvecMigrator {
         for (const testEmbedding of testQueries) {
           // Compare vector vs halfvec similarity
           const vectorResults = await prisma.$queryRawUnsafe<any[]>(`
-            SELECT id, 1 - (embedding <=> $1::extensions.vector) as similarity
+            SELECT id, 1 - (embedding <=> $1::vector) as similarity
             FROM ${table}
             WHERE embedding IS NOT NULL
             ORDER BY embedding <=> $1::vector
@@ -230,7 +230,7 @@ class HalfvecMigrator {
           `, testEmbedding);
           
           const halfvecResults = await prisma.$queryRawUnsafe<any[]>(`
-            SELECT id, 1 - (embedding_halfvec <=> $1::extensions.halfvec) as similarity
+            SELECT id, 1 - (embedding_halfvec <=> $1::halfvec) as similarity
             FROM ${table}
             WHERE embedding_halfvec IS NOT NULL
             ORDER BY embedding_halfvec <=> $1::halfvec

--- a/rag-app/app/services/embedding-generation.server.ts
+++ b/rag-app/app/services/embedding-generation.server.ts
@@ -364,7 +364,7 @@ export class EmbeddingGenerationService {
         const results = pageId 
           ? await prisma.$queryRawUnsafe<any[]>(`
               SELECT * FROM search_embeddings(
-                $1::extensions.vector,
+                $1::vector,
                 $2::uuid,
                 $3::uuid,
                 $4::integer,
@@ -373,7 +373,7 @@ export class EmbeddingGenerationService {
             `, vectorString, workspaceId, pageId, limit, similarityThreshold)
           : await prisma.$queryRawUnsafe<any[]>(`
               SELECT * FROM search_embeddings(
-                $1::extensions.vector,
+                $1::vector,
                 $2::uuid,
                 NULL::uuid,
                 $3::integer,

--- a/rag-app/app/services/halfvec-embedding-generation.server.ts
+++ b/rag-app/app/services/halfvec-embedding-generation.server.ts
@@ -202,7 +202,7 @@ export class HalfvecEmbeddingGenerationService {
               ${workspaceId}::uuid,
               ${chunk.text},
               ${chunk.index},
-              ${vectorString}::extensions.halfvec(1536),
+              ${vectorString}::halfvec(1536),
               ${JSON.stringify({
                 ...metadata,
                 vectorType: 'halfvec',
@@ -228,8 +228,8 @@ export class HalfvecEmbeddingGenerationService {
               ${workspaceId}::uuid,
               ${chunk.text},
               ${chunk.index},
-              ${vectorString}::extensions.vector(1536),
-              ${vectorString}::extensions.halfvec(1536),
+              ${vectorString}::vector(1536),
+              ${vectorString}::halfvec(1536),
               ${JSON.stringify({
                 ...metadata,
                 vectorType: 'both',
@@ -254,7 +254,7 @@ export class HalfvecEmbeddingGenerationService {
               ${workspaceId}::uuid,
               ${chunk.text},
               ${chunk.index},
-              ${vectorString}::extensions.vector(1536),
+              ${vectorString}::vector(1536),
               ${JSON.stringify({
                 ...metadata,
                 vectorType: 'vector',
@@ -311,7 +311,7 @@ export class HalfvecEmbeddingGenerationService {
               ${workspaceId}::uuid,
               ${chunk.text},
               ${chunk.index},
-              ${vectorString}::extensions.halfvec(1536),
+              ${vectorString}::halfvec(1536),
               ${JSON.stringify({
                 ...metadata,
                 vectorType: 'halfvec',
@@ -339,8 +339,8 @@ export class HalfvecEmbeddingGenerationService {
               ${workspaceId}::uuid,
               ${chunk.text},
               ${chunk.index},
-              ${vectorString}::extensions.vector(1536),
-              ${vectorString}::extensions.halfvec(1536),
+              ${vectorString}::vector(1536),
+              ${vectorString}::halfvec(1536),
               ${JSON.stringify({
                 ...metadata,
                 vectorType: 'both',
@@ -367,7 +367,7 @@ export class HalfvecEmbeddingGenerationService {
               ${workspaceId}::uuid,
               ${chunk.text},
               ${chunk.index},
-              ${vectorString}::extensions.vector(1536),
+              ${vectorString}::vector(1536),
               ${JSON.stringify({
                 ...metadata,
                 vectorType: 'vector',

--- a/rag-app/app/services/halfvec-search.server.ts
+++ b/rag-app/app/services/halfvec-search.server.ts
@@ -108,13 +108,13 @@ async function searchWithHalfvecColumn(
         pe.page_id,
         pe.chunk_text as content,
         pe.metadata,
-        1 - (pe.embedding_halfvec <=> ${vectorString}::extensions.halfvec) as similarity
+        1 - (pe.embedding_halfvec <=> ${vectorString}::halfvec) as similarity
       FROM page_embeddings pe
       WHERE 
         pe.workspace_id = ${workspaceId}::uuid
         AND pe.embedding_halfvec IS NOT NULL
         AND (${pageId}::uuid IS NULL OR pe.page_id = ${pageId}::uuid)
-        AND 1 - (pe.embedding_halfvec <=> ${vectorString}::extensions.halfvec) > ${threshold}
+        AND 1 - (pe.embedding_halfvec <=> ${vectorString}::halfvec) > ${threshold}
       
       UNION ALL
       
@@ -124,13 +124,13 @@ async function searchWithHalfvecColumn(
         be.page_id,
         be.chunk_text as content,
         be.metadata,
-        1 - (be.embedding_halfvec <=> ${vectorString}::extensions.halfvec) as similarity
+        1 - (be.embedding_halfvec <=> ${vectorString}::halfvec) as similarity
       FROM block_embeddings be
       WHERE 
         be.workspace_id = ${workspaceId}::uuid
         AND be.embedding_halfvec IS NOT NULL
         AND (${pageId}::uuid IS NULL OR be.page_id = ${pageId}::uuid)
-        AND 1 - (be.embedding_halfvec <=> ${vectorString}::extensions.halfvec) > ${threshold}
+        AND 1 - (be.embedding_halfvec <=> ${vectorString}::halfvec) > ${threshold}
       
       UNION ALL
       
@@ -140,13 +140,13 @@ async function searchWithHalfvecColumn(
         dre.page_id,
         dre.chunk_text as content,
         dre.metadata,
-        1 - (dre.embedding_halfvec <=> ${vectorString}::extensions.halfvec) as similarity
+        1 - (dre.embedding_halfvec <=> ${vectorString}::halfvec) as similarity
       FROM database_row_embeddings dre
       WHERE 
         dre.workspace_id = ${workspaceId}::uuid
         AND dre.embedding_halfvec IS NOT NULL
         AND (${pageId}::uuid IS NULL OR dre.page_id = ${pageId}::uuid)
-        AND 1 - (dre.embedding_halfvec <=> ${vectorString}::extensions.halfvec) > ${threshold}
+        AND 1 - (dre.embedding_halfvec <=> ${vectorString}::halfvec) > ${threshold}
       
       UNION ALL
       
@@ -156,12 +156,12 @@ async function searchWithHalfvecColumn(
         NULL as page_id,
         e.chunk_text as content,
         e.metadata,
-        1 - (e.embedding_halfvec <=> ${vectorString}::extensions.halfvec) as similarity
+        1 - (e.embedding_halfvec <=> ${vectorString}::halfvec) as similarity
       FROM embeddings e
       WHERE 
         (e.metadata->>'workspaceId')::text = ${workspaceId}
         AND e.embedding_halfvec IS NOT NULL
-        AND 1 - (e.embedding_halfvec <=> ${vectorString}::extensions.halfvec) > ${threshold}
+        AND 1 - (e.embedding_halfvec <=> ${vectorString}::halfvec) > ${threshold}
     )
     SELECT * FROM all_embeddings
     ORDER BY similarity DESC
@@ -194,13 +194,13 @@ async function searchWithVectorColumn(
         pe.page_id,
         pe.chunk_text as content,
         pe.metadata,
-        1 - (pe.embedding <=> ${vectorString}::extensions.vector) as similarity
+        1 - (pe.embedding <=> ${vectorString}::vector) as similarity
       FROM page_embeddings pe
       WHERE 
         pe.workspace_id = ${workspaceId}::uuid
         AND pe.embedding IS NOT NULL
         AND (${pageId}::uuid IS NULL OR pe.page_id = ${pageId}::uuid)
-        AND 1 - (pe.embedding <=> ${vectorString}::extensions.vector) > ${threshold}
+        AND 1 - (pe.embedding <=> ${vectorString}::vector) > ${threshold}
       
       UNION ALL
       
@@ -210,13 +210,13 @@ async function searchWithVectorColumn(
         be.page_id,
         be.chunk_text as content,
         be.metadata,
-        1 - (be.embedding <=> ${vectorString}::extensions.vector) as similarity
+        1 - (be.embedding <=> ${vectorString}::vector) as similarity
       FROM block_embeddings be
       WHERE 
         be.workspace_id = ${workspaceId}::uuid
         AND be.embedding IS NOT NULL
         AND (${pageId}::uuid IS NULL OR be.page_id = ${pageId}::uuid)
-        AND 1 - (be.embedding <=> ${vectorString}::extensions.vector) > ${threshold}
+        AND 1 - (be.embedding <=> ${vectorString}::vector) > ${threshold}
       
       UNION ALL
       
@@ -226,13 +226,13 @@ async function searchWithVectorColumn(
         dre.page_id,
         dre.chunk_text as content,
         dre.metadata,
-        1 - (dre.embedding <=> ${vectorString}::extensions.vector) as similarity
+        1 - (dre.embedding <=> ${vectorString}::vector) as similarity
       FROM database_row_embeddings dre
       WHERE 
         dre.workspace_id = ${workspaceId}::uuid
         AND dre.embedding IS NOT NULL
         AND (${pageId}::uuid IS NULL OR dre.page_id = ${pageId}::uuid)
-        AND 1 - (dre.embedding <=> ${vectorString}::extensions.vector) > ${threshold}
+        AND 1 - (dre.embedding <=> ${vectorString}::vector) > ${threshold}
       
       UNION ALL
       
@@ -242,12 +242,12 @@ async function searchWithVectorColumn(
         NULL as page_id,
         e.chunk_text as content,
         e.metadata,
-        1 - (e.embedding <=> ${vectorString}::extensions.vector) as similarity
+        1 - (e.embedding <=> ${vectorString}::vector) as similarity
       FROM embeddings e
       WHERE 
         (e.metadata->>'workspaceId')::text = ${workspaceId}
         AND e.embedding IS NOT NULL
-        AND 1 - (e.embedding <=> ${vectorString}::extensions.vector) > ${threshold}
+        AND 1 - (e.embedding <=> ${vectorString}::vector) > ${threshold}
     )
     SELECT * FROM all_embeddings
     ORDER BY similarity DESC
@@ -401,7 +401,7 @@ export async function updateSearchEmbeddingsFunction() {
             ue.chunk_text,
             CASE 
               WHEN ue.embedding_halfvec IS NULL THEN 0.0
-              ELSE 1 - (ue.embedding_halfvec <=> query_embedding::extensions.halfvec)
+              ELSE 1 - (ue.embedding_halfvec <=> query_embedding::halfvec)
             END AS similarity,
             ue.metadata
           FROM unified_embeddings_halfvec ue
@@ -409,7 +409,7 @@ export async function updateSearchEmbeddingsFunction() {
             AND (page_uuid IS NULL OR ue.page_id = page_uuid)
             AND (
               ue.embedding_halfvec IS NULL 
-              OR (1 - (ue.embedding_halfvec <=> query_embedding::extensions.halfvec)) >= similarity_threshold
+              OR (1 - (ue.embedding_halfvec <=> query_embedding::halfvec)) >= similarity_threshold
             )
           ORDER BY 
             CASE 
@@ -417,7 +417,7 @@ export async function updateSearchEmbeddingsFunction() {
               ELSE 0 
             END,
             CASE 
-              WHEN ue.embedding_halfvec IS NOT NULL THEN ue.embedding_halfvec <=> query_embedding::extensions.halfvec
+              WHEN ue.embedding_halfvec IS NOT NULL THEN ue.embedding_halfvec <=> query_embedding::halfvec
               ELSE NULL
             END
           LIMIT result_limit;

--- a/rag-app/app/services/monitoring/vector-metrics.server.ts
+++ b/rag-app/app/services/monitoring/vector-metrics.server.ts
@@ -267,7 +267,7 @@ export class VectorMetricsService {
         // Time vector search
         const vectorStart = Date.now();
         const vectorResults = await prisma.$queryRaw<any[]>`
-          SELECT id, chunk_text, 1 - (embedding <=> ${vectorString}::extensions.vector) as similarity
+          SELECT id, chunk_text, 1 - (embedding <=> ${vectorString}::vector) as similarity
           FROM page_embeddings
           WHERE embedding IS NOT NULL
           ORDER BY embedding <=> ${vectorString}::vector
@@ -279,7 +279,7 @@ export class VectorMetricsService {
         // Time halfvec search
         const halfvecStart = Date.now();
         const halfvecResults = await prisma.$queryRaw<any[]>`
-          SELECT id, chunk_text, 1 - (embedding_halfvec <=> ${vectorString}::extensions.halfvec) as similarity
+          SELECT id, chunk_text, 1 - (embedding_halfvec <=> ${vectorString}::halfvec) as similarity
           FROM page_embeddings
           WHERE embedding_halfvec IS NOT NULL
           ORDER BY embedding_halfvec <=> ${vectorString}::halfvec

--- a/rag-app/app/services/rag/async-embedding.service.ts
+++ b/rag-app/app/services/rag/async-embedding.service.ts
@@ -270,7 +270,7 @@ export class AsyncEmbeddingService {
             ${page.workspaceId}::uuid,
             ${embedding.text},
             ${embedding.chunkIndex},
-            ${embedding.embedding}::extensions.vector,
+            ${embedding.embedding}::vector,
             ${JSON.stringify(embedding.metadata)}::jsonb,
             NOW(),
             NOW()

--- a/rag-app/app/services/rag/memory-optimized-indexing.service.ts
+++ b/rag-app/app/services/rag/memory-optimized-indexing.service.ts
@@ -274,7 +274,7 @@ export class MemoryOptimizedIndexingService {
               ${page.workspaceId}::uuid,
               ${emb.text},
               ${emb.chunkIndex},
-              ${vectorString}::extensions.vector,
+              ${vectorString}::vector,
               ${JSON.stringify({
                 ...emb.metadata,
                 indexedAt: new Date().toISOString(),

--- a/rag-app/app/services/rag/optimized-indexing.service.ts
+++ b/rag-app/app/services/rag/optimized-indexing.service.ts
@@ -221,7 +221,7 @@ export class OptimizedIndexingService {
                 ${page.workspaceId}::uuid,
                 ${emb.text},
                 ${emb.chunkIndex},
-                ${vectorString}::extensions.vector,
+                ${vectorString}::vector,
                 ${JSON.stringify({
                   ...emb.metadata,
                   indexedAt: new Date().toISOString(),

--- a/rag-app/app/services/rag/rag-indexing.service.ts
+++ b/rag-app/app/services/rag/rag-indexing.service.ts
@@ -312,7 +312,7 @@ export class RAGIndexingService {
             ${page.workspaceId}::uuid,
             ${chunk.text},
             ${chunk.chunkIndex},
-            ${vectorString}::extensions.vector,
+            ${vectorString}::vector,
             ${JSON.stringify({
               ...chunk.metadata,
               indexedAt: new Date().toISOString(),

--- a/rag-app/app/services/rag/ultra-light-indexing.service.ts
+++ b/rag-app/app/services/rag/ultra-light-indexing.service.ts
@@ -474,7 +474,7 @@ export class UltraLightIndexingService {
                   ${page.workspaceId}::uuid,
                   ${chunk.text},
                   ${chunk.index},
-                  ${vectorString}::extensions.vector,
+                  ${vectorString}::vector,
                   ${JSON.stringify({
                     pageTitle: page.title,
                     chunkSize: chunk.text.length,

--- a/rag-app/app/services/rag/workers/ultra-light-embedding-worker.ts
+++ b/rag-app/app/services/rag/workers/ultra-light-embedding-worker.ts
@@ -268,7 +268,7 @@ export class UltraLightEmbeddingWorker {
               ${workspaceId}::uuid,
               ${chunk.text},
               ${chunk.index},
-              ${vectorString}::extensions.vector,
+              ${vectorString}::vector,
               ${JSON.stringify({
                 pageTitle,
                 chunkSize: chunk.text.length,


### PR DESCRIPTION
…icit schema

- Reverted all ::extensions.vector back to ::vector
- Reverted all ::extensions.halfvec back to ::halfvec
- Search path now handles schema resolution via SET search_path TO public, extensions
- This fixes the 'operator does not exist' errors in production