### PR TITLE
fix: Remove transactions and fix timeouts for Vercel deployment

### DIFF
--- a/rag-app/app/services/connection-pool-manager.server.ts
+++ b/rag-app/app/services/connection-pool-manager.server.ts
@@ -51,7 +51,7 @@ export class ConnectionPoolManager {
     const config = getPoolingConfig();
     const { 
       maxRetries = config.port === 6543 ? 3 : 1,
-      timeout = 30000, // Increased to 30 seconds for indexing operations
+      timeout = 9000, // 9 seconds for Vercel Hobby (10s limit with 1s buffer)
       isolationLevel = 'ReadCommitted'
     } = options;
     
@@ -71,7 +71,7 @@ export class ConnectionPoolManager {
               return operation(tx as PrismaClient);
             },
             {
-              maxWait: 20000, // Increased to 20s for queue wait
+              maxWait: 8000, // 8s max wait for Vercel constraints
               timeout: timeout, // Use the timeout from options (30s default)
               isolationLevel,
             }

--- a/rag-app/app/services/embedding-generation.server.ts
+++ b/rag-app/app/services/embedding-generation.server.ts
@@ -363,6 +363,16 @@ export class EmbeddingGenerationService {
         // Use Prisma.sql for proper type handling
         // Use search_embeddings function which returns: id, content, metadata, similarity, source_type, source_id
         await ensureVectorSearchPath();
+        
+        // Log the actual parameters being sent
+        this.logger.info('🔍 Calling search_embeddings with params:', {
+          vectorLength: vectorString.length,
+          workspaceId,
+          pageId,
+          limit,
+          similarityThreshold
+        });
+        
         const results = pageId 
           ? await prisma.$queryRawUnsafe<any[]>(`
               SELECT * FROM search_embeddings(


### PR DESCRIPTION
- Removed ALL transaction usage from UltraLightIndexingService
- Fixed transaction timeouts from 30s to 9s for Vercel Hobby plan (10s limit)
- Fixed maxWait from 20s to 8s to fit within Vercel constraints
- Added logging to search_embeddings function calls for debugging
- Fixed cleanup operations to work without transactions

This resolves:
- Transaction timeout errors (P2028) in production
- AI block not finding content despite embeddings existing
- Vercel function timeout issues