### PR TITLE
fix: Resolve infinite re-render loop in ChatSidebar with stable empty…

### DIFF
--- a/rag-app/app/components/chat/ChatSidebar.tsx
+++ b/rag-app/app/components/chat/ChatSidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { X, Send, Upload, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useFetcher } from '@remix-run/react';
-import { useChatMessages, useChatDataFiles, useChatSidebar, useChatConnection } from '~/stores/chat-store-fixed';
+import { useChatMessages, useChatDataFiles, useChatSidebar, useChatConnection } from '~/stores/chat-store-ultimate-fix';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 import { FileUploadZone } from './FileUploadZone';

--- a/rag-app/app/components/chat/ChatSidebarDebug.tsx
+++ b/rag-app/app/components/chat/ChatSidebarDebug.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { X, Send, Upload, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useFetcher } from '@remix-run/react';
-import { useChatMessages, useChatDataFiles, useChatSidebar, useChatConnection } from '~/stores/chat-store-fixed';
+import { useChatMessages, useChatDataFiles, useChatSidebar, useChatConnection } from '~/stores/chat-store-ultimate-fix';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 import { FileUploadZone } from './FileUploadZone';

--- a/rag-app/app/components/chat/ChatSidebarMinimal.tsx
+++ b/rag-app/app/components/chat/ChatSidebarMinimal.tsx
@@ -1,0 +1,54 @@
+import { ChevronLeft, X } from 'lucide-react';
+import { useMinimalChatStore } from '~/stores/chat-store-minimal';
+
+interface ChatSidebarMinimalProps {
+  pageId: string;
+}
+
+// Test with minimal Zustand store
+export function ChatSidebarMinimal({ pageId }: ChatSidebarMinimalProps) {
+  const { isOpen, messages, setOpen, addMessage } = useMinimalChatStore();
+  
+  console.log('[ChatSidebarMinimal] Render', { pageId, isOpen, messageCount: messages.length });
+  
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed right-0 top-1/2 -translate-y-1/2 bg-white border-l border-gray-200 rounded-l-lg p-2 shadow-lg hover:bg-gray-50 z-40"
+      >
+        <ChevronLeft className="w-5 h-5" />
+      </button>
+    );
+  }
+  
+  return (
+    <div className="fixed right-0 top-0 h-full w-[30%] bg-white border-l border-gray-200 shadow-xl z-50 p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-lg font-semibold">Minimal Chat</h2>
+        <button onClick={() => setOpen(false)}>
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+      
+      <div className="mb-4">
+        <button 
+          onClick={() => addMessage(`Test message ${messages.length + 1}`)}
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          Add Message
+        </button>
+      </div>
+      
+      <div className="space-y-2">
+        {messages.map((msg, i) => (
+          <div key={i} className="p-2 bg-gray-100 rounded">
+            {msg}
+          </div>
+        ))}
+      </div>
+      
+      <p className="text-gray-500 mt-4">Page: {pageId}</p>
+    </div>
+  );
+}

--- a/rag-app/app/routes/editor.$pageId.tsx
+++ b/rag-app/app/routes/editor.$pageId.tsx
@@ -2,8 +2,8 @@ import { json, LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
 import { useLoaderData, useFetcher, Link, NavLink, useLocation } from "@remix-run/react";
 import { EnhancedBlockEditor } from "~/components/editor/EnhancedBlockEditor";
 import { ClientOnly } from "~/components/ClientOnly";
-// Using debug version for production troubleshooting
-import { ChatSidebar } from "~/components/chat/ChatSidebarDebug";
+// Fixed version with stable empty array references
+import { ChatSidebar } from "~/components/chat/ChatSidebar";
 import { prisma } from "~/utils/db.server";
 import { requireUser, getUser } from "~/services/auth/auth.server";
 import { useState, useEffect, useCallback, useRef } from "react";
@@ -1123,9 +1123,8 @@ export default function EditorPage() {
         </div>
       </div>
       
-      {/* Chat Sidebar - TEMPORARILY DISABLED FOR DEBUGGING */}
-      {/* Issue: React Error #185 infinite loop in production */}
-      {/* <ClientOnly fallback={null}>
+      {/* Chat Sidebar - Fixed with stable empty array references */}
+      <ClientOnly fallback={null}>
         <ChatSidebar 
           pageId={page.id}
           onSendMessage={async (message) => {
@@ -1137,7 +1136,7 @@ export default function EditorPage() {
             // TODO: Implement file upload and DuckDB table creation
           }}
         />
-      </ClientOnly> */}
+      </ClientOnly>
       
       {/* Command Palette - rendered as modal */}
       <ClientOnly fallback={null}>

--- a/rag-app/app/routes/test-sidebar.tsx
+++ b/rag-app/app/routes/test-sidebar.tsx
@@ -1,10 +1,11 @@
 import { ChatSidebarSimple } from '~/components/chat/ChatSidebarSimple';
+import { ChatSidebarMinimal } from '~/components/chat/ChatSidebarMinimal';
 import { ChatSidebar } from '~/components/chat/ChatSidebar';
 import { ClientOnly } from '~/components/ClientOnly';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function TestSidebar() {
-  const [testType, setTestType] = useState<'simple' | 'full' | 'wrapped'>('simple');
+  const [testType, setTestType] = useState<'simple' | 'minimal' | 'full' | 'wrapped'>('simple');
   
   return (
     <div className="min-h-screen bg-gray-100 p-8">
@@ -21,10 +22,16 @@ export default function TestSidebar() {
               Simple (No Store)
             </button>
             <button
+              onClick={() => setTestType('minimal')}
+              className={`px-4 py-2 rounded ${testType === 'minimal' ? 'bg-blue-500 text-white' : 'bg-gray-200'}`}
+            >
+              Minimal Store
+            </button>
+            <button
               onClick={() => setTestType('full')}
               className={`px-4 py-2 rounded ${testType === 'full' ? 'bg-blue-500 text-white' : 'bg-gray-200'}`}
             >
-              Full (With Store)
+              Full Store
             </button>
             <button
               onClick={() => setTestType('wrapped')}
@@ -46,6 +53,10 @@ export default function TestSidebar() {
       {/* Render selected sidebar type */}
       {testType === 'simple' && (
         <ChatSidebarSimple pageId="test-page-123" />
+      )}
+      
+      {testType === 'minimal' && (
+        <ChatSidebarMinimal pageId="test-page-123" />
       )}
       
       {testType === 'full' && (

--- a/rag-app/app/stores/chat-store-minimal.ts
+++ b/rag-app/app/stores/chat-store-minimal.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+// Absolute minimal store to test basic functionality
+interface MinimalChatState {
+  isOpen: boolean;
+  messages: string[];
+  setOpen: (open: boolean) => void;
+  addMessage: (message: string) => void;
+}
+
+export const useMinimalChatStore = create<MinimalChatState>((set) => ({
+  isOpen: false,
+  messages: [],
+  setOpen: (open) => set({ isOpen: open }),
+  addMessage: (message) => set((state) => ({ 
+    messages: [...state.messages, message] 
+  })),
+}));

--- a/rag-app/app/stores/chat-store-ultimate-fix.ts
+++ b/rag-app/app/stores/chat-store-ultimate-fix.ts
@@ -1,0 +1,241 @@
+import { create } from 'zustand';
+import { shallow } from 'zustand/shallow';
+
+export interface ChatMessage {
+  id: string;
+  pageId: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  metadata?: {
+    sql?: string;
+    chartType?: string;
+    blockId?: string;
+    error?: string;
+    dataFiles?: string[];
+  };
+  timestamp: Date;
+  isStreaming?: boolean;
+}
+
+export interface DataFile {
+  id: string;
+  pageId: string;
+  filename: string;
+  tableName: string;
+  schema: Array<{
+    name: string;
+    type: string;
+    sampleData?: any[];
+  }>;
+  rowCount: number;
+  sizeBytes: number;
+  uploadedAt: Date;
+}
+
+// Empty arrays that are referentially stable
+const EMPTY_MESSAGES: ChatMessage[] = [];
+const EMPTY_FILES: DataFile[] = [];
+
+interface ChatState {
+  // State - using objects instead of Maps
+  messages: Record<string, ChatMessage[]>;
+  dataFiles: Record<string, DataFile[]>;
+  activePageId: string | null;
+  isSidebarOpen: boolean;
+  isLoading: boolean;
+  streamingMessageId: string | null;
+  draftMessage: string;
+  connectionStatus: 'connected' | 'disconnected' | 'connecting';
+  
+  // Actions
+  addMessage: (pageId: string, message: Omit<ChatMessage, 'id' | 'timestamp'>) => void;
+  updateMessage: (pageId: string, messageId: string, updates: Partial<ChatMessage>) => void;
+  deleteMessage: (pageId: string, messageId: string) => void;
+  clearMessages: (pageId: string) => void;
+  
+  addDataFile: (pageId: string, file: Omit<DataFile, 'id' | 'uploadedAt'>) => void;
+  removeDataFile: (pageId: string, fileId: string) => void;
+  clearDataFiles: (pageId: string) => void;
+  
+  setActivePageId: (pageId: string | null) => void;
+  toggleSidebar: () => void;
+  setSidebarOpen: (open: boolean) => void;
+  
+  setLoading: (loading: boolean) => void;
+  setStreamingMessageId: (messageId: string | null) => void;
+  setDraftMessage: (message: string) => void;
+  setConnectionStatus: (status: 'connected' | 'disconnected' | 'connecting') => void;
+}
+
+export const useChatStore = create<ChatState>()((set, get) => ({
+  // Initial state
+  messages: {},
+  dataFiles: {},
+  activePageId: null,
+  isSidebarOpen: false,
+  isLoading: false,
+  streamingMessageId: null,
+  draftMessage: '',
+  connectionStatus: 'disconnected',
+  
+  // Message actions
+  addMessage: (pageId, message) => set((state) => {
+    const pageMessages = state.messages[pageId] || [];
+    const newMessage: ChatMessage = {
+      ...message,
+      id: `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      pageId,
+      timestamp: new Date(),
+    };
+    
+    return {
+      messages: {
+        ...state.messages,
+        [pageId]: [...pageMessages, newMessage],
+      },
+    };
+  }),
+  
+  updateMessage: (pageId, messageId, updates) => set((state) => {
+    const pageMessages = state.messages[pageId];
+    if (!pageMessages) return state;
+    
+    return {
+      messages: {
+        ...state.messages,
+        [pageId]: pageMessages.map(msg => 
+          msg.id === messageId ? { ...msg, ...updates } : msg
+        ),
+      },
+    };
+  }),
+  
+  deleteMessage: (pageId, messageId) => set((state) => {
+    const pageMessages = state.messages[pageId];
+    if (!pageMessages) return state;
+    
+    return {
+      messages: {
+        ...state.messages,
+        [pageId]: pageMessages.filter(msg => msg.id !== messageId),
+      },
+    };
+  }),
+  
+  clearMessages: (pageId) => set((state) => ({
+    messages: {
+      ...state.messages,
+      [pageId]: [],
+    },
+  })),
+  
+  // Data file actions
+  addDataFile: (pageId, file) => set((state) => {
+    const pageFiles = state.dataFiles[pageId] || [];
+    const newFile: DataFile = {
+      ...file,
+      id: `file-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      pageId,
+      uploadedAt: new Date(),
+    };
+    
+    return {
+      dataFiles: {
+        ...state.dataFiles,
+        [pageId]: [...pageFiles, newFile],
+      },
+    };
+  }),
+  
+  removeDataFile: (pageId, fileId) => set((state) => {
+    const pageFiles = state.dataFiles[pageId];
+    if (!pageFiles) return state;
+    
+    return {
+      dataFiles: {
+        ...state.dataFiles,
+        [pageId]: pageFiles.filter(file => file.id !== fileId),
+      },
+    };
+  }),
+  
+  clearDataFiles: (pageId) => set((state) => ({
+    dataFiles: {
+      ...state.dataFiles,
+      [pageId]: [],
+    },
+  })),
+  
+  // UI state actions
+  setActivePageId: (pageId) => set({ activePageId: pageId }),
+  toggleSidebar: () => set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
+  setSidebarOpen: (open) => set({ isSidebarOpen: open }),
+  
+  // Status actions
+  setLoading: (loading) => set({ isLoading: loading }),
+  setStreamingMessageId: (messageId) => set({ streamingMessageId: messageId }),
+  setDraftMessage: (message) => set({ draftMessage: message }),
+  setConnectionStatus: (status) => set({ connectionStatus: status }),
+}));
+
+// Critical fix: Use stable empty arrays and memoized selectors
+export const useChatMessages = (pageId: string) => {
+  // Use stable reference for empty array
+  const messages = useChatStore((state) => state.messages[pageId]) || EMPTY_MESSAGES;
+  const addMessage = useChatStore((state) => state.addMessage);
+  const updateMessage = useChatStore((state) => state.updateMessage);
+  const deleteMessage = useChatStore((state) => state.deleteMessage);
+  const clearMessages = useChatStore((state) => state.clearMessages);
+  
+  return {
+    messages,
+    addMessage: (message: Omit<ChatMessage, 'id' | 'timestamp' | 'pageId'>) => 
+      addMessage(pageId, message),
+    updateMessage: (messageId: string, updates: Partial<ChatMessage>) => 
+      updateMessage(pageId, messageId, updates),
+    deleteMessage: (messageId: string) => deleteMessage(pageId, messageId),
+    clearMessages: () => clearMessages(pageId),
+  };
+};
+
+export const useChatDataFiles = (pageId: string) => {
+  // Use stable reference for empty array
+  const dataFiles = useChatStore((state) => state.dataFiles[pageId]) || EMPTY_FILES;
+  const addDataFile = useChatStore((state) => state.addDataFile);
+  const removeDataFile = useChatStore((state) => state.removeDataFile);
+  const clearDataFiles = useChatStore((state) => state.clearDataFiles);
+  
+  return {
+    dataFiles,
+    addDataFile: (file: Omit<DataFile, 'id' | 'uploadedAt' | 'pageId'>) => 
+      addDataFile(pageId, file),
+    removeDataFile: (fileId: string) => removeDataFile(pageId, fileId),
+    clearDataFiles: () => clearDataFiles(pageId),
+  };
+};
+
+export const useChatSidebar = () => {
+  const isSidebarOpen = useChatStore((state) => state.isSidebarOpen);
+  const toggleSidebar = useChatStore((state) => state.toggleSidebar);
+  const setSidebarOpen = useChatStore((state) => state.setSidebarOpen);
+  
+  return {
+    isSidebarOpen,
+    toggleSidebar,
+    setSidebarOpen,
+  };
+};
+
+export const useChatConnection = () => {
+  const connectionStatus = useChatStore((state) => state.connectionStatus);
+  const setConnectionStatus = useChatStore((state) => state.setConnectionStatus);
+  const isLoading = useChatStore((state) => state.isLoading);
+  const setLoading = useChatStore((state) => state.setLoading);
+  
+  return {
+    connectionStatus,
+    setConnectionStatus,
+    isLoading,
+    setLoading,
+  };
+};


### PR DESCRIPTION
… array references

- Root cause: state.messages[pageId] || [] was creating new array references on every render
- Solution: Use stable EMPTY_MESSAGES and EMPTY_FILES constants to maintain referential equality
- This prevents React from detecting false changes when no messages exist for a pageId
- Re-enabled ChatSidebar in editor with the fixed store implementation
- All chat components now use chat-store-ultimate-fix.ts with stable references