### PR TITLE
fix: Fix DuckDB export service and improve API error handling

### DIFF
--- a/rag-app/app/routes/api.data.files.$pageId.tsx
+++ b/rag-app/app/routes/api.data.files.$pageId.tsx
@@ -79,11 +79,20 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     });
 
     return json({ files: dataFiles });
-  } catch (error) {
+  } catch (error: any) {
     logger.error('Failed to fetch data files:', error);
+    
+    // Provide more detailed error for debugging
+    const errorMessage = error?.message || 'Failed to fetch data files';
+    const isAuthError = errorMessage.includes('auth') || errorMessage.includes('user') || errorMessage.includes('session');
+    
     return json(
-      { error: 'Failed to fetch data files' },
-      { status: 500 }
+      { 
+        error: 'Failed to fetch data files',
+        details: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+        type: isAuthError ? 'auth' : 'unknown'
+      },
+      { status: isAuthError ? 401 : 500 }
     );
   }
 };
@@ -205,11 +214,20 @@ export const action: ActionFunction = async ({ request, params }) => {
     }
 
     return json({ error: 'Method not allowed' }, { status: 405 });
-  } catch (error) {
+  } catch (error: any) {
     logger.error('Failed to process data file action:', error);
+    
+    // Provide more detailed error for debugging
+    const errorMessage = error?.message || 'Failed to process data file action';
+    const isAuthError = errorMessage.includes('auth') || errorMessage.includes('user') || errorMessage.includes('session');
+    
     return json(
-      { error: 'Failed to process data file action' },
-      { status: 500 }
+      { 
+        error: 'Failed to process data file action',
+        details: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+        type: isAuthError ? 'auth' : 'unknown'
+      },
+      { status: isAuthError ? 401 : 500 }
     );
   }
 };

--- a/rag-app/app/services/duckdb/duckdb-export.client.ts
+++ b/rag-app/app/services/duckdb/duckdb-export.client.ts
@@ -1,11 +1,11 @@
-import { DuckDBService } from './duckdb-service.client';
+import { getDuckDB } from './duckdb-service.client';
 
 export class DuckDBExportService {
   private static instance: DuckDBExportService;
-  private duckdb: DuckDBService;
+  private duckdb: ReturnType<typeof getDuckDB>;
   
   private constructor() {
-    this.duckdb = DuckDBService.getInstance();
+    this.duckdb = getDuckDB();
   }
   
   static getInstance(): DuckDBExportService {
@@ -23,10 +23,10 @@ export class DuckDBExportService {
       console.log('[DuckDBExport] Exporting table as JSON:', tableName);
       
       // Get table data
-      const data = await this.duckdb.query(`SELECT * FROM ${tableName}`);
+      const data = await this.duckdb.executeQuery(`SELECT * FROM ${tableName}`);
       
       // Get table schema
-      const schemaResult = await this.duckdb.query(`
+      const schemaResult = await this.duckdb.executeQuery(`
         SELECT column_name, data_type 
         FROM information_schema.columns 
         WHERE table_name = '${tableName}'


### PR DESCRIPTION
- Fix DuckDBExportService to use executeQuery instead of query method
- Use getDuckDB() instead of DuckDBService.getInstance()
- Add detailed error logging to data files API endpoint
- Distinguish between auth errors (401) and server errors (500)
- Provide error details in development mode for debugging

🤖 Generated with [Claude Code](https://claude.ai/code)